### PR TITLE
Refactor `scripts/mapdata.py`

### DIFF
--- a/scripts/mapdata.py
+++ b/scripts/mapdata.py
@@ -1,7 +1,6 @@
 import json
 import re
 from typing import Dict, Union
-import multiprocessing
 
 
 quote_keys_pattern = re.compile(r'([\{ ])([a-z]+):') # e.g. room: "Portable 1" → "room": "Portable 1"
@@ -59,16 +58,15 @@ def main(input_path: str = 'data.txt', output_path: str = 'data.geojson') -> Non
   """
   Runs the main program: use the data form input_path, convert it to a geojson format and save it to output_path
   """
-  with multiprocessing.Pool() as p:
-    with open(input_path) as input_file:
-      # usually points to metropolis/core/static/core/js/map/data.txt
-      with open(output_path, 'w') as output_file:
-        # open both files at the same time to show that they are both being used
-        data = {
-          'type': 'FeatureCollection',
-          'features': p.map(process_line, input_file),
-        }
-        json.dump(data, output_file)
+  with open(input_path) as input_file:
+    # usually points to metropolis/core/static/core/js/map/data.txt
+    with open(output_path, 'w') as output_file:
+      # open both files at the same time to show that they are both being used
+      data = {
+        'type': 'FeatureCollection',
+        'features': list(map(process_line, input_file)),
+      }
+      json.dump(data, output_file)
 
 if __name__ == '__main__':
   main()

--- a/scripts/mapdata.py
+++ b/scripts/mapdata.py
@@ -1,3 +1,8 @@
+import sys
+
+if sys.version_info[0] < 3 or sys.version_info[1] < 5: # 3.5+
+  raise ImportError('Only Python 3.5+ is supported.')
+
 import json
 import re
 from typing import Dict, Union


### PR DESCRIPTION
This PR refactors `scripts/mapdata.py` to make it easier to understand.

Summary of changes:
- make every step of the conversion a function (i.e. strip, fix_json_key, to_feature)
  - can easily add more steps if needed
- use the map() function instead of for loops
- use the json module for (de)serialization of data
- add explanation where necessary
- speed is basically the same (around 0.01s slower)
- does not print debug output during execution anymore