### PR TITLE
Fix Squashed Featured Image

### DIFF
--- a/core/static/core/css/blog-detail.css
+++ b/core/static/core/css/blog-detail.css
@@ -104,6 +104,7 @@ hr {
         width: 100%;
         margin: 0;
         margin-bottom: 20px;
+        object-fit: cover; /* crop image when constrained by max-height (#143) */
     }
     .title {
         font-size: 2.5rem;


### PR DESCRIPTION
Featured images would become squashed if constrained by [`.card-image`'s `max-height` rule](https://github.com/wlmac/metropolis/blob/master/core/static/core/css/blog-detail.css#L103).

Examples:
- [Humans of WLMAC: Day 6](https://maclyonsden.com/blog/HoW-1) ([archived](https://web.archive.org/web/20210925000746/https://maclyonsden.com/blog/HoW-1))
![image](https://user-images.githubusercontent.com/45807097/134750961-40055186-334f-46ab-a0f1-2c001542c4d5.png)

Tested on (using DevTools / Inspect):
- Firefox 92.0
- Chromium 93.0.4577.82 (used in screenshot)