### PR TITLE
Make time format more precise

### DIFF
--- a/core/static/core/js/schedule.js
+++ b/core/static/core/js/schedule.js
@@ -1,6 +1,37 @@
 const DateTime = luxon.DateTime;
+const Duration = luxon.Duration;
 let scheduleData = [];
 let scheduleIsPersonal = false;
+
+function formatHours(hours) {
+    return `${hours} ${hours == 1 ? "hour" : "hours"}`;
+}
+
+function formatMinutes(minutes) {
+    return `${minutes} ${minutes == 1 ? "minute" : "minutes"}`;
+}
+
+function formatSeconds(seconds) {
+    return `${seconds} ${seconds == 1 ? "second" : "seconds"}`;
+}
+
+function formatHMS(hours, minutes, seconds) {
+    if (hours > 0) { // e.g. 2 hours 25 minutes
+        return `${formatHours(hours)} ${formatMinutes(minutes)}`
+    } else if (minutes >= 10) { // e.g. 15 minutes
+        return `${formatMinutes(minutes)}`
+    } else if (minutes > 0) { // e.g. 5 minutes 26 seconds
+        return `${formatMinutes(minutes)} ${formatSeconds(seconds)}`
+    } else { // e.g. 26 seconds
+        return `${formatSeconds(seconds)}`
+    }
+}
+
+function formatTimeIntervalDuration(startTime, endTime) {
+    let duration_milliseconds = startTime.until(endTime).toDuration().toMillis();
+    let duration = Duration.fromObject({ hours: 0, minutes: 0, seconds: 0, milliseconds: duration_milliseconds }).normalize();
+    return formatHMS(duration.hours, duration.minutes, duration.seconds);
+}
 
 function getDateTimeNow() {
     return DateTime.now();
@@ -59,46 +90,46 @@ function update() {
             currentCourse = courseData.course;
 
             if (now < DateTime.fromISO(courseData.time.start)) {
-                description = `Starting ${DateTime.fromISO(courseData.time.start).toRelative({base: now})}`;
-                } else {
-                    description = `Ending ${DateTime.fromISO(courseData.time.end).toRelative({base: now})}`;
-                    }
-                } else {
-                    if (todayData.length > 0) {
-                        currentCourse = 'School Over';
-                        description = 'Enjoy your evening!';
-                    } else {
-                        currentCourse = 'No School';
-                        description = 'Enjoy your day!';
-                    }
-                }
+                description = `Starting in ${formatTimeIntervalDuration(now, DateTime.fromISO(courseData.time.start))}`;
             } else {
-                currentCourse = "Unknown";
-                description = "We were unable to fetch your schedule.";
+                description = `Ending in ${formatTimeIntervalDuration(now, DateTime.fromISO(courseData.time.end))}`;
             }
-
-            $(".schedule-course").text(currentCourse);
-            $(".schedule-description").text(description);
-
-            if (todayData) {
-                if (todayData.length > 0) $(".schedule-cycle").text(todayData[0].cycle);
-                let todayCoursesEl = $(".schedule-today-courses").empty();
-                for (let i = 0; i < todayData.length; i++) {
-                    if (todayData[i].course) {
-                        let courseDescription;
-                        if (scheduleIsPersonal) courseDescription = `${todayData[i].description.course} - ${todayData[i].course}`;
-                        else courseDescription = `${todayData[i].description.course}`;
-
-                        let courseEl = $("<span class='schedule-today-course'></span>").text(courseDescription);
-                        if (todayData[i].course === currentCourse) courseEl.attr("data-active", true);
-                        todayCoursesEl.append(courseEl);
-                        if (i < todayData.length) todayCoursesEl.append($("<br>"));
-                    }
-                }
+        } else {
+            if (todayData.length > 0) {
+                currentCourse = 'School Over';
+                description = 'Enjoy your evening!';
+            } else {
+                currentCourse = 'No School';
+                description = 'Enjoy your day!';
             }
         }
+    } else {
+        currentCourse = "Unknown";
+        description = "We were unable to fetch your schedule.";
+    }
 
-        $(document).ready(function () {
-            setup();
-            setInterval(update, 1000);
-        });
+    $(".schedule-course").text(currentCourse);
+    $(".schedule-description").text(description);
+
+    if (todayData) {
+        if (todayData.length > 0) $(".schedule-cycle").text(todayData[0].cycle);
+        let todayCoursesEl = $(".schedule-today-courses").empty();
+        for (let i = 0; i < todayData.length; i++) {
+            if (todayData[i].course) {
+                let courseDescription;
+                if (scheduleIsPersonal) courseDescription = `${todayData[i].description.course} - ${todayData[i].course}`;
+                else courseDescription = `${todayData[i].description.course}`;
+
+                let courseEl = $("<span class='schedule-today-course'></span>").text(courseDescription);
+                if (todayData[i].course === currentCourse) courseEl.attr("data-active", true);
+                todayCoursesEl.append(courseEl);
+                if (i < todayData.length) todayCoursesEl.append($("<br>"));
+            }
+        }
+    }
+}
+
+$(document).ready(function () {
+    setup();
+    setInterval(update, 1000);
+});


### PR DESCRIPTION
Fixes #46 

This PR improves the formatting of the time information on the dashboard. Currently, a time duration like 1 hour 40 minutes gets rounded down to `1 hour`, which is imprecise. With this PR, 1 hour 40 minutes would get formatted as `1 hour 40 minutes`.

Rules used for time formatting:

**t >= 1 hour:** display hours and minutes (e.g. 2 hours 25 minutes)
**10 minutes <= t < 1 hour:** display minutes (e.g. 15 minutes)
**1 minute <= t < 10 minutes:** display minutes and seconds (e.g. 5 minutes 26 seconds)
**t < 1 minute:** display seconds (e.g. 26 seconds)

This PR also fixes the indentation in the `schedule.js` file, which is why some of the diff may look weird.