### PR TITLE
cors origins: only allow itself

### DIFF
--- a/metropolis/settings.py
+++ b/metropolis/settings.py
@@ -393,7 +393,9 @@ CORS_ALLOW_METHODS = [
     "OPTIONS",
 ]
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = [
+    'https://maclyonsden.com',
+]
 
 # Color settings
 

--- a/metropolis/settings.py
+++ b/metropolis/settings.py
@@ -385,7 +385,7 @@ REST_FRAMEWORK = {
 
 # CORS settings
 
-CORS_URLS_REGEX = r"^.*/data/?$"
+CORS_URLS_REGEX = r"^.*/api/?$"
 
 CORS_ALLOW_METHODS = [
     "GET",


### PR DESCRIPTION
This will only allow the site itself.

Seems to work without any CORS issues on Chrome and Firefox.