### PR TITLE
Restore Remember Me button on login page

### DIFF
--- a/core/static/core/css/account.css
+++ b/core/static/core/css/account.css
@@ -94,7 +94,7 @@ select {
 }
 
 .login-btn {
-    margin-top: 10px;
+    margin-top: 30px;
     width: 100%;
 }
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -52,11 +52,11 @@
                             {{ field }}
                             {{ field.errors }}
                         {% else %}
-<!--                         <div class="col s12">
+                        <div class="col s12">
                             <label for="id_remember" class="valign-wrapper">
                                 <input class="filled-in checkbox-blue" type="checkbox" name="remember" id="id_remember">
-                                <span>Remember Me</span> -->
-                                {# {{ field.errors }} #}
+                                <span>Remember Me</span>
+                                {{ field.errors }}
                             </label> 
                         {% endif %}
 


### PR DESCRIPTION
The Remember Me button works using the [django-allauth setting `ACCOUNT_SESSION_REMEMBER`](https://django-allauth.readthedocs.io/en/latest/configuration.html), which is `None` (ask the user) by default.

This PR restores code that was commented out/changed in commit
ccbcd0fec93f70f441b4eec7d8fdce98c12533ae.