### PR TITLE
Fix broken page titles on authentication views

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -3,7 +3,7 @@
 {% load settings_tags %}
 {% load static %}
 
-{% block title %}{{ title }} | Metropolis{% endblock %}
+{% block title %}{% block head_title %}{{ title }}{% endblock %} | Metropolis{% endblock %}
 
 {% block head %}
 <link rel="stylesheet" href="{% settings_value 'THEME_CSS' %}">

--- a/core/templates/core/calendar/view.html
+++ b/core/templates/core/calendar/view.html
@@ -1,10 +1,6 @@
 {% extends 'core/base.html' %}
 {% load static %}
 
-{% block title %}
-    Calendar
-{% endblock %}
-
 {% block deps %}
     <link rel="stylesheet" href="{% static 'css/fullcalendar.min.css' %}" type="text/css"/>
     <script src="{% static 'js/fullcalendar.min.js' %}"></script>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -3,6 +3,8 @@
 {% load static %}
 {% load settings_tags %}
 
+{% block head_title %}{% trans "Login" %}{% endblock %}
+
 {% block head %}
 <link rel="stylesheet" href="{% static 'core/css/base.css' %}">
 <link rel="stylesheet" href="{% settings_value 'THEME_CSS' %}">

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block head_title %}{% trans "Sign Out" %}{% endblock %}
+{% block head_title %}{% trans "Logout" %}{% endblock %}
 
 {% block content %}
 <h1>{% trans "Log Out" %}</h1>

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -3,6 +3,8 @@
 {% load settings_tags %}
 {% load static %}
 
+{% block head_title %}{% trans "Sign Up" %}{% endblock %}
+
 {% block head %}
 <link rel="stylesheet" href="{% static 'core/css/base.css' %}">
 <link rel="stylesheet" href="{% settings_value 'THEME_CSS' %}">


### PR DESCRIPTION
Closes #134
Since django-allauth templates already have page title names in the head_title block, page titles can be rendered by using the head_title block in the core/base.html template.

Also, in order to match what Metropolis currently has on the navigation bar, this commit changes the default django-allauth titles "Sign In", "Signup", and "Sign Out" to "Login", "Sign Up", and "Logout", respectively.