### PR TITLE
Move get current site into bodge_replace()

### DIFF
--- a/core/templatetags/markdown_tags.py
+++ b/core/templatetags/markdown_tags.py
@@ -9,11 +9,11 @@ from martor.utils import markdownify
 
 register = template.Library()
 
-current_site = Site.objects.get_current()
 bodge_pattern = re.compile(f"\[([^\]]*)\]\(/")
 
 
 def bodge_replace(match):
+    current_site = Site.objects.get_current()
     return f"[{match.group(1)}](https://{current_site.domain}/"
 
 


### PR DESCRIPTION
This fixes the failing GitHub Actions check.

When `Site.objects.get_current()` is put into the global scope, it gets evaluated whenever `python manage.py <any command>`  is run. This is fine when a database has already been built with information about the current site, but when there is no database (when running the tests using GitHub Actions or when doing a fresh install of metropolis), there is an error:
```
 django.db.utils.OperationalError: no such table: django_site
```

By moving the call to `Site.objects.get_current()` into a function, this error can be prevented.