### PR TITLE
lazy loading for anns

### DIFF
--- a/core/api/urls.py
+++ b/core/api/urls.py
@@ -4,7 +4,6 @@ from rest_framework.routers import SimpleRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .views import *
-from ..views import AnnouncementCards
 
 router = SimpleRouter()
 
@@ -19,7 +18,6 @@ urlpatterns = [
         name="api_announcement_feed",
     ),
     path("announcements", AnnouncementListAll.as_view(), name="api_all_announcements"),
-    path("announcements/cards", AnnouncementCards.as_view(), name="api_announcements_card"),
     path(
         "announcements/changes",
         AnnouncementChangeStream.as_view(),

--- a/core/api/urls.py
+++ b/core/api/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import SimpleRouter
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from .views import *
+from ..views import AnnouncementCards
 
 router = SimpleRouter()
 
@@ -18,6 +19,7 @@ urlpatterns = [
         name="api_announcement_feed",
     ),
     path("announcements", AnnouncementListAll.as_view(), name="api_all_announcements"),
+    path("announcements/cards", AnnouncementCards.as_view(), name="api_announcements_card"),
     path(
         "announcements/changes",
         AnnouncementChangeStream.as_view(),

--- a/core/static/core/js/announcement/lazy.js
+++ b/core/static/core/js/announcement/lazy.js
@@ -3,28 +3,6 @@
  * @description : lazy loading of annoucements
  */
 
-let loadIn = new Map();
-let pagesLoaded = 0;
-let loadedLast = false;
-let loading = false;
-let cardsElem;
-
-function loadBuffer(){
-    if(!loading){
-        loading = true;
-        while(!loadedLast && loadIn.has(pagesLoaded + 1)){
-            cardsElem.insertAdjacentHTML('beforeend', loadIn.get(pagesLoaded + 1));
-            const nexts = cardsElem.getElementsByClassName('has-next');
-            for (let i = nexts.length - 2; i >= 0; i--) {
-                nexts[i].remove();
-            }
-            if(nexts[nexts.length - 1].classList.contains("no-more")) loadedLast = true;
-            pagesLoaded += 1;
-        }
-        loading = false;
-    }
-}
-
 async function loadPage(page, feed) {
     const response = await fetch(
         `/announcements/cards?page=${page}&feed=${feed}`,
@@ -32,18 +10,51 @@ async function loadPage(page, feed) {
     return response.text();
 }
 
-async function insertPage(page, feed) {
-    console.log(`loading page ${page} for feed ${feed}`);
-    const cards = await loadPage(page, feed);
-    loadIn.set(page, cards);
-    loadBuffer();
-}
+function setup(feedSlug, initial_cards) {
+    let page = 1
 
-function setup(feedSlug) {
-    cardsElem = document.getElementById(`cards-${feedSlug}`);
-    return async (page) => {
-        if (!loadedLast) {
-            await insertPage(page, feedSlug);
+    // temporary buffer of cards
+    let loadIn = new Map();
+    let pagesLoaded = initial_cards;
+    let loadedLast = false;
+    let loading = false;
+    let cardsElem = document.getElementById(`cards-${feedSlug}`);
+
+    // loads the buffer into the webpage
+    function loadBuffer(){
+        // guarantee that only one thread is running (don't want announcements to be added in a different order)
+        if(!loading){
+            loading = true;
+            // add the next card if we haven't loaded the last card yet
+            while(!loadedLast && loadIn.has(pagesLoaded + 1)){
+                cardsElem.insertAdjacentHTML('beforeend', loadIn.get(pagesLoaded + 1));
+                const nexts = cardsElem.getElementsByClassName('has-next');
+                for (let i = nexts.length - 2; i >= 0; i--) {
+                    nexts[i].remove();
+                }
+                if(nexts[nexts.length - 1].classList.contains("no-more")) loadedLast = true;
+                pagesLoaded += 1;
+            }
+            loading = false;
+        }
+    }
+
+    // adds the card to the buffer
+    async function insertPage(page, feed) {
+        console.log(`loading page ${page} for feed ${feed}`);
+        const cards = await loadPage(page, feed);
+        loadIn.set(page, cards);
+        loadBuffer();
+    }
+
+    // called when we want to add more cards - asynchronously called, updates page at the start
+    return async (pageLen) => {
+        let start = page
+        page += pageLen
+        for(let i = start; i < start + pageLen; i++){
+            if (!loadedLast) {
+                await insertPage(i, feedSlug);
+            }
         }
     }
 }

--- a/core/static/core/js/announcement/lazy.js
+++ b/core/static/core/js/announcement/lazy.js
@@ -3,36 +3,47 @@
  * @description : lazy loading of annoucements
  */
 
+let loadIn = new Map();
+let pagesLoaded = 0;
+let loadedLast = false;
+let loading = false;
+let cardsElem;
+
+function loadBuffer(){
+    if(!loading){
+        loading = true;
+        while(!loadedLast && loadIn.has(pagesLoaded + 1)){
+            cardsElem.insertAdjacentHTML('beforeend', loadIn.get(pagesLoaded + 1));
+            const nexts = cardsElem.getElementsByClassName('has-next');
+            for (let i = nexts.length - 2; i >= 0; i--) {
+                nexts[i].remove();
+            }
+            if(nexts[nexts.length - 1].classList.contains("no-more")) loadedLast = true;
+            pagesLoaded += 1;
+        }
+        loading = false;
+    }
+}
+
 async function loadPage(page, feed) {
     const response = await fetch(
         `/announcements/cards?page=${page}&feed=${feed}`,
     );
-    const cards = response.text();
-    return cards;
+    return response.text();
 }
 
-async function insertPage(cardsElem, page, feed) {
+async function insertPage(page, feed) {
     console.log(`loading page ${page} for feed ${feed}`);
     const cards = await loadPage(page, feed);
-    cardsElem.insertAdjacentHTML('beforeend', cards);
-    const nexts = cardsElem.getElementsByClassName('has-next');
-    for (let i = nexts.length - 2; i >= 0; i--) {
-        nexts[i].remove();
-    }
-    if (nexts[nexts.length-1].classList.contains('no-more')) {
-        return false;
-    }
-    return true;
+    loadIn.set(page, cards);
+    loadBuffer();
 }
 
 function setup(feedSlug) {
-    let page = 1;
-    let hasNext = true;
-    const cardsElem = document.getElementById(`cards-${feedSlug}`);
-    return async () => {
-        if (hasNext) {
-            hasNext = await insertPage(cardsElem, page, feedSlug);
-            page += 1;
+    cardsElem = document.getElementById(`cards-${feedSlug}`);
+    return async (page) => {
+        if (!loadedLast) {
+            await insertPage(page, feedSlug);
         }
     }
 }

--- a/core/static/core/js/announcement/lazy.js
+++ b/core/static/core/js/announcement/lazy.js
@@ -1,0 +1,40 @@
+/**
+ * @author      : Ken Shibata (kenxshibata@gmail.com)
+ * @description : lazy loading of annoucements
+ */
+
+async function loadPage(page, feed) {
+    const response = await fetch(
+        `/announcements/cards?page=${page}&feed=${feed}`,
+    );
+    const cards = response.text();
+    return cards;
+}
+
+async function insertPage(cardsElem, page, feed) {
+    console.log(`loading page ${page} for feed ${feed}`);
+    const cards = await loadPage(page, feed);
+    cardsElem.insertAdjacentHTML('beforeend', cards);
+    const nexts = cardsElem.getElementsByClassName('has-next');
+    for (let i = nexts.length - 2; i >= 0; i--) {
+        nexts[i].remove();
+    }
+    if (nexts[nexts.length-1].classList.contains('no-more')) {
+        return false;
+    }
+    return true;
+}
+
+function setup(feedSlug) {
+    let page = 1;
+    let hasNext = true;
+    const cardsElem = document.getElementById(`cards-${feedSlug}`);
+    return async () => {
+        if (hasNext) {
+            hasNext = await insertPage(cardsElem, page, feedSlug);
+            page += 1;
+        }
+    }
+}
+
+export { setup };

--- a/core/templates/core/announcement/cards.html
+++ b/core/templates/core/announcement/cards.html
@@ -1,0 +1,5 @@
+{% load link_tags %}
+{% load static %}
+{% for announcement in feed %}
+{% include "./card_snippet.html" %}
+{% endfor %}

--- a/core/templates/core/announcement/cards.html
+++ b/core/templates/core/announcement/cards.html
@@ -3,3 +3,8 @@
 {% for announcement in feed %}
 {% include "./card_snippet.html" %}
 {% endfor %}
+{% if feed.has_next %}
+<span class="has-next">Loading more…</span>
+{% else %}
+<span class="has-next no-more">That's all the announcements you have for now!</span>
+{% endif %}

--- a/core/templates/core/announcement/list.html
+++ b/core/templates/core/announcement/list.html
@@ -26,33 +26,24 @@
             import { setup } from "{% static 'core/js/announcement/lazy.js' %}";
 
             const feeds = new Map();
-            feeds.set("all", setup("all"));
+            feeds.set("all", setup("all", {{ initial_limit }}));
             {% comment %}
             {% if user.is_authenticated %}
             feeds.set("my", setup("my"));
             {% endif %}
             {% endcomment %}
             {% for feed_custom in feeds_custom %}
-            feeds.set("{{feed_custom.0.pk}}", setup("{{feed_custom.0.pk}}"));
+            feeds.set("{{feed_custom.0.pk}}", setup("{{feed_custom.0.pk}}", {{ initial_limit }}));
             {% endfor %}
 
             const urlParams = new URLSearchParams(window.location.search);
 
-            let pageLen = 2;
+            let pageLen = {{per_page}};
             let margin = 300;
-            let page = 1;
 
-            function update(){
-                for(let i = 0; i < pageLen; i++){
-                    feeds.get(urlParams.get("feed"))(page);
-                    page += 1;
-                }
-            }
-
-            update()
             window.addEventListener("scroll", () => {
                 if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - margin) {
-                    update()
+                    feeds.get(urlParams.get("feed"))(pageLen)
                 }
             });
         </script>

--- a/core/templates/core/announcement/list.html
+++ b/core/templates/core/announcement/list.html
@@ -99,6 +99,11 @@
         </div>
         -->
         <div class="cards" id="cards-all">
+            {% for announcement in feed_all %}
+            {% include "./card_snippet.html" %}
+            {% empty %}
+            <div class="message">There are no announcements posted at this time. Check back in a bit!</div>
+            {% endfor %}
         </div>
         {% comment %}
         {% if user.is_authenticated %}

--- a/core/templates/core/announcement/list.html
+++ b/core/templates/core/announcement/list.html
@@ -4,6 +4,7 @@
 
 {% block deps %}
 <link rel="stylesheet" href="{% static 'core/css/announcement-list.css' %}">
+<link rel="modulepreload" href="{% static 'core/js/announcement/lazy.js' %}" as="script">
 {% endblock %}
 
 {% block main %}
@@ -17,9 +18,32 @@
             {% endif %}
             {% endcomment %}
             {% for feed_custom in feeds_custom %}
-            <li class="header" id="{{feed_custom.0.name|lower}}">{{feed_custom.0.name|upper}}</li>
+            <li class="header" id="{{feed_custom.0.pk}}">{{feed_custom.0.name|upper}}</li>
             {% endfor %}
         </ul>
+        {% if lazy_loading %}
+        <script type="module">
+            import { setup } from "{% static 'core/js/announcement/lazy.js' %}";
+
+            const feeds = new Map();
+            feeds.set("all", setup("all"));
+            {% comment %}
+            {% if user.is_authenticated %}
+            feeds.set("my", setup("my"));
+            {% endif %}
+            {% endcomment %}
+            {% for feed_custom in feeds_custom %}
+            feeds.set("{{feed_custom.0.pk}}", setup("{{feed_custom.0.pk}}"));
+            {% endfor %}
+
+            const urlParams = new URLSearchParams(window.location.search);
+            window.addEventListener("scroll", () => {
+                if((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
+                    feeds.get(urlParams.get("feed"))();
+                }
+            });
+        </script>
+        {% endif %}
         <script>
             $(document).ready(function() {
                 var urlParams = new URLSearchParams(window.location.search);
@@ -80,7 +104,7 @@
         {% endif %}
         {% endcomment %}
         {% for feed_custom in feeds_custom %}
-        <div class="cards" id="cards-{{feed_custom.0.name|lower}}">
+        <div class="cards" id="cards-{{feed_custom.0.pk}}">
             {% for announcement in feed_custom.1 %}
             {% include "./card_snippet.html" %}
             {% empty %}

--- a/core/templates/core/announcement/list.html
+++ b/core/templates/core/announcement/list.html
@@ -37,9 +37,22 @@
             {% endfor %}
 
             const urlParams = new URLSearchParams(window.location.search);
+
+            let pageLen = 2;
+            let margin = 300;
+            let page = 1;
+
+            function update(){
+                for(let i = 0; i < pageLen; i++){
+                    feeds.get(urlParams.get("feed"))(page);
+                    page += 1;
+                }
+            }
+
+            update()
             window.addEventListener("scroll", () => {
-                if((window.innerHeight + window.scrollY) >= document.body.offsetHeight) {
-                    feeds.get(urlParams.get("feed"))();
+                if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - margin) {
+                    update()
                 }
             });
         </script>
@@ -86,11 +99,6 @@
         </div>
         -->
         <div class="cards" id="cards-all">
-            {% for announcement in feed_all %}
-            {% include "./card_snippet.html" %}
-            {% empty %}
-            <div class="message">There are no announcements posted at this time. Check back in a bit!</div>
-            {% endfor %}
         </div>
         {% comment %}
         {% if user.is_authenticated %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, path
 from django.conf import settings
+from django.urls import include, path
 
 from . import views
 
@@ -48,5 +48,9 @@ urlpatterns = [
 
 if settings.LAZY_LOADING:
     urlpatterns.append(
-        path("announcements/cards", views.AnnouncementCards.as_view(), name="api_announcements_card"),
+        path(
+            "announcements/cards",
+            views.AnnouncementCards.as_view(),
+            name="api_announcements_card",
+        ),
     )

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from django.conf import settings
 
 from . import views
 
@@ -44,3 +45,8 @@ urlpatterns = [
     path("teapot", views.Teapot.as_view(), name="teapot"),
     path("justinian", views.Justinian.as_view(), name="justinian"),
 ]
+
+if settings.LAZY_LOADING:
+    urlpatterns.append(
+        path("announcements/cards", views.AnnouncementCards.as_view(), name="api_announcements_card"),
+    )

--- a/core/views/post.py
+++ b/core/views/post.py
@@ -14,35 +14,50 @@ from .. import models
 from . import mixins
 
 
+def custom_feed(request, pk: int):
+    assert models.Organization.objects.filter(
+        pk=pk
+    ).exists(), "pk for feed doesn't exist"
+    custom_feed_organization = models.Organization.objects.get(
+        pk=pk
+    )
+    return (
+        custom_feed_organization,
+        custom_feed_organization.get_feed(user=request.user),
+    )
+
+
 class AnnouncementCards(TemplateView):
     template_name = "core/announcement/cards.html"
 
     def dispatch(self, request, *args, **kwargs):
-        self.count = request.GET.get("count", '1')
-        if not isinstance(self.count, str):
-            return HttpResponseBadRequest("invalid count")
-        if not self.count.isnumeric():
-            return HttpResponseBadRequest("invalid count (non-numeric)")
-        self.page = request.GET.get("page", '1')
+        self.page = request.GET.get("page", None)
         if not isinstance(self.page, str):
             return HttpResponseBadRequest("invalid page")
         if not self.page.isnumeric():
             return HttpResponseBadRequest("invalid page (non-numeric)")
-        self.feed = request.GET.get("feed", "all")
-        if self.feed not in ("all", "my"):
-            return HttpResponseBadRequest("invalid feed")
+        self.feed = request.GET.get("feed", None)
         if self.feed == "my":
             if not self.request.user.is_authenticated:
                 return HttpResponseForbidden("not authenticated")
-        response = super().dispatch(request, *args, **kwargs)
-        response['X-Has-Next'] = "true" if self.posts.has_next() else "false"
-        return response
+        elif self.feed == "all":
+            pass
+        else:
+            if not isinstance(self.feed, str):
+                return HttpResponseBadRequest("invalid feed")
+            if not self.feed.isnumeric():
+                return HttpResponseBadRequest("invalid feed (non-numeric)")
+        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        feed = self.request.user.get_feed() if self.feed == "my" \
-            else models.Announcement.get_all(user=self.request.user)
-        paginator = Paginator(feed, self.count)
+        if self.feed == "my":
+            feed = self.request.user.get_feed()
+        elif self.feed == "all":
+            feed = models.Announcement.get_all(user=self.request.user)
+        else:
+            feed = custom_feed(self.request, int(self.feed))[1]
+        paginator = Paginator(feed, settings.LAZY_LOADING["per_page"])
         try:
             self.posts = paginator.page(self.page)
         except EmptyPage:
@@ -59,25 +74,19 @@ class AnnouncementList(TemplateView, mixins.TitleMixin):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        if settings.LAZY_LOADING:
+            context["lazy_loading"] = True
+
         context["feed_all"] = models.Announcement.get_all(user=self.request.user)
+        if settings.LAZY_LOADING:
+            context["feed_all"] = context["feed_all"][:settings.LAZY_LOADING["initial_limit"]]
 
         if self.request.user.is_authenticated:
             context["feed_my"] = self.request.user.get_feed()
+            if settings.LAZY_LOADING:
+                context["feed_my"] = context["feed_my"][:settings.LAZY_LOADING["initial_limit"]]
 
-        context["feeds_custom"] = []
-        for custom_feed_organization_pk in settings.ANNOUNCEMENTS_CUSTOM_FEEDS:
-            assert models.Organization.objects.filter(
-                pk=custom_feed_organization_pk
-            ).exists(), "pk for feed doesn't exist"
-            custom_feed_organization = models.Organization.objects.get(
-                pk=custom_feed_organization_pk
-            )
-            context["feeds_custom"].append(
-                (
-                    custom_feed_organization,
-                    custom_feed_organization.get_feed(user=self.request.user),
-                )
-            )
+        context["feeds_custom"] = [custom_feed(self.request, pk)[:settings.LAZY_LOADING["initial_limit"]] for pk in settings.ANNOUNCEMENTS_CUSTOM_FEEDS]
 
         """ to-do: search bar, DNR
         query = self.request.GET.get('q' ,'')

--- a/core/views/post.py
+++ b/core/views/post.py
@@ -73,6 +73,8 @@ class AnnouncementList(TemplateView, mixins.TitleMixin):
 
         if settings.LAZY_LOADING:
             context["lazy_loading"] = True
+            context["initial_limit"] = settings.LAZY_LOADING["initial_limit"]
+            context["per_page"] = settings.LAZY_LOADING["per_page"]
 
         context["feed_all"] = models.Announcement.get_all(user=self.request.user)
         if settings.LAZY_LOADING:

--- a/metropolis/settings.py
+++ b/metropolis/settings.py
@@ -677,7 +677,7 @@ CURRENT_THEME = "winter"
 
 # Lazy Loading
 
-LAZY_LOADING = { # set to False to disable
+LAZY_LOADING = {  # set to False to disable
     "per_page": 1,
     "initial_limit": 1,
 }

--- a/metropolis/settings.py
+++ b/metropolis/settings.py
@@ -675,6 +675,13 @@ THEMES = {
 
 CURRENT_THEME = "winter"
 
+# Lazy Loading
+
+LAZY_LOADING = { # set to False to disable
+    "per_page": 1,
+    "initial_limit": 1,
+}
+
 # Misc settings
 
 SITE_ID = 1


### PR DESCRIPTION
implements lazy loading for announcements:
- `AnnouncementCards` returns cards in HTML for specific pages
- `lazy.js` (and some JS in `core/templates/core/announcement/list.html`) loads cards when the end of the page is reached
- `LAZY_LOADING` in settings can be used to configure (ie anns per page, initial limit)

Note to self: change `LAZY_LOADING` to saner values in prod config