### PR TITLE
events: iCalendar view

### DIFF
--- a/core/templates/core/calendar/view.html
+++ b/core/templates/core/calendar/view.html
@@ -16,7 +16,7 @@
     </div>
     <div id="details">
         <div class="container">
-            <a href="https://sisikyo.herokuapp.com/events/public.ics">URL to iCalendar (use this to add to Google Calendar)</a>
+            <a href="{% url 'calendar_ical' %}">URL to iCalendar (use this to add to Google Calendar)</a>
             <h3 id="detailsCurrentDay"></h3>
             <p id="detailsCurrentWeek"></p>
             <hr>

--- a/core/urls.py
+++ b/core/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
     path("blog", views.BlogPostList.as_view(), name="blogpost_list"),
     path("blog/<str:slug>", views.BlogPostDetail.as_view(), name="blogpost_detail"),
     path("calendar", views.CalendarView.as_view(), name="calendar"),
+    path("calendar.ics", views.CalendarFeed(), name="calendar_ical"),
     path("map", views.MapView.as_view(), name="map"),
     path("about", views.AboutView.as_view(), name="about"),
     path("teapot", views.Teapot.as_view(), name="teapot"),

--- a/core/views/index.py
+++ b/core/views/index.py
@@ -66,7 +66,7 @@ class CalendarFeed(ICalFeed):
 
     def item_link(self, item):
         # TODO: implement by-pk link
-        return reverse("calendar")
+        return reverse("calendar") + f"?pk={item.pk}"  # NOTE: workaround for UID
 
     def item_categories(self, item):
         return [tag.name for tag in item.tags.all()] \

--- a/core/views/index.py
+++ b/core/views/index.py
@@ -46,7 +46,11 @@ class CalendarFeed(ICalFeed):
     file_name = "public_calendar.ics"
 
     def items(self):
-        return models.Event.get_events(user=None).order_by('-start_date')
+        now = timezone.now()
+        padding = settings.ICAL_PADDING
+        return models.Event.get_events(user=None).filter(
+            end_date__gte=now - padding, start_date__lte=now + padding,
+        ).order_by('-start_date')
 
     def item_title(self, item):
         return item.name

--- a/metropolis/settings.py
+++ b/metropolis/settings.py
@@ -777,6 +777,9 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
 }
 
+# iCalendar Feed
+ICAL_PADDING = timedelta(days=4*7)
+
 try:
     from metropolis.config import *
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ sqlparse==0.4.2
 urllib3==1.26.7
 webencodings==0.5.1
 wrapt==1.13.3
+django_ical==1.8.3


### PR DESCRIPTION
`CalendarFeed` returns events that are in the timeframe `settings.ICAL_PADDING` before and after now (i.e. if the padding is 2 days, the feed (for today 2022-05-26) would return events that are in the timeframe of 2022-05-24 to 2022-05-28)).