### PR TITLE
is_instructional is useful again!

### DIFF
--- a/core/api/views/events.py
+++ b/core/api/views/events.py
@@ -15,69 +15,28 @@ class EventsList(ListAPIViewWithFallback):
     pagination_class = None
 
     def get_queryset(self):
-        start = timezone.now()
-        if self.request.data.get("start"):
-            start = self.request.data.get("start")
-        elif self.request.query_params.get("start"):
-            start = self.request.query_params.get("start")
+        start = (
+            self.request.data.get("start")
+            or self.request.query_params.get("start")
+            or timezone.now()
+        )
+        end = self.request.data.get("end") or self.request.query_params.get("end")
+
+        events = models.Event.objects.filter(end_date__gte=start)
+
+        if end:
+            events = events.filter(start_date__lte=end)
 
         if not self.request.user.is_anonymous:
-            if self.request.data.get("end"):
-                end = self.request.data.get("end")
-                events = (
-                    models.Event.objects.filter(
-                        end_date__gte=start, start_date__lte=end
-                    )
-                    .filter(
-                        Q(is_public=True)
-                        | Q(organization__member=self.request.user.id)
-                        | Q(organization__supervisors=self.request.user.id)
-                        | Q(organization__execs=self.request.user.id)
-                    )
-                    .distinct()
-                    .order_by("start_date")
-                )
-            elif self.request.query_params.get("end"):
-                end = self.request.query_params.get("end")
-                events = (
-                    models.Event.objects.filter(
-                        end_date__gte=start, start_date__lte=end
-                    )
-                    .filter(
-                        Q(is_public=True)
-                        | Q(organization__member=self.request.user.id)
-                        | Q(organization__supervisors=self.request.user.id)
-                        | Q(organization__execs=self.request.user.id)
-                    )
-                    .distinct()
-                    .order_by("start_date")
-                )
-            else:
-                events = (
-                    models.Event.objects.filter(end_date__gte=start)
-                    .filter(
-                        Q(is_public=True)
-                        | Q(organization__member=self.request.user.id)
-                        | Q(organization__supervisors=self.request.user.id)
-                        | Q(organization__execs=self.request.user.id)
-                    )
-                    .distinct()
-                    .order_by("start_date")
-                )
+            events = events.filter(
+                Q(is_public=True)
+                | Q(organization__member=self.request.user.id)
+                | Q(organization__supervisors=self.request.user.id)
+                | Q(organization__execs=self.request.user.id)
+            ).distinct()
         else:
-            if self.request.data.get("end"):
-                end = self.request.data.get("end")
-                events = models.Event.objects.filter(
-                    end_date__gte=start, start_date__lte=end, is_public=True
-                ).order_by("start_date")
-            elif self.request.query_params.get("end"):
-                end = self.request.query_params.get("end")
-                events = models.Event.objects.filter(
-                    end_date__gte=start, start_date__lte=end, is_public=True
-                ).order_by("start_date")
-            else:
-                events = models.Event.objects.filter(
-                    end_date__gte=start, is_public=True
-                ).order_by("start_date")
+            events = events.filter(Q(is_public=True))
+
+        events = events.order_by("start_date")
 
         return events

--- a/core/api/views/events.py
+++ b/core/api/views/events.py
@@ -29,7 +29,10 @@ class EventsList(ListAPIViewWithFallback):
                         end_date__gte=start, start_date__lte=end
                     )
                     .filter(
-                        Q(is_public=True) | Q(organization__member=self.request.user.id)
+                        Q(is_public=True)
+                        | Q(organization__member=self.request.user.id)
+                        | Q(organization__supervisors=self.request.user.id)
+                        | Q(organization__execs=self.request.user.id)
                     )
                     .distinct()
                     .order_by("start_date")
@@ -41,7 +44,10 @@ class EventsList(ListAPIViewWithFallback):
                         end_date__gte=start, start_date__lte=end
                     )
                     .filter(
-                        Q(is_public=True) | Q(organization__member=self.request.user.id)
+                        Q(is_public=True)
+                        | Q(organization__member=self.request.user.id)
+                        | Q(organization__supervisors=self.request.user.id)
+                        | Q(organization__execs=self.request.user.id)
                     )
                     .distinct()
                     .order_by("start_date")
@@ -50,7 +56,10 @@ class EventsList(ListAPIViewWithFallback):
                 events = (
                     models.Event.objects.filter(end_date__gte=start)
                     .filter(
-                        Q(is_public=True) | Q(organization__member=self.request.user.id)
+                        Q(is_public=True)
+                        | Q(organization__member=self.request.user.id)
+                        | Q(organization__supervisors=self.request.user.id)
+                        | Q(organization__execs=self.request.user.id)
                     )
                     .distinct()
                     .order_by("start_date")

--- a/core/forms.py
+++ b/core/forms.py
@@ -216,6 +216,7 @@ class EventAdminForm(forms.ModelForm):
 
         self.fields["schedule_format"].initial = "default"
         self.fields["term"].initial = models.Term.get_current()
+        self.fields["is_instructional"].disabled = True
 
         if "instance" in kwargs and kwargs["instance"] is not None:
             instance = kwargs["instance"]

--- a/core/management/commands/add_events.py
+++ b/core/management/commands/add_events.py
@@ -80,7 +80,6 @@ class Command(BaseCommand):
                     "term": options["term"] if options["term"] else None,
                     "organization": None,
                     "schedule_format": "default",
-                    "is_instructional": True,
                     "is_public": True,
                     "should_announce": False,
                 }
@@ -182,7 +181,7 @@ class Command(BaseCommand):
                     event_data["term"]
                 )
 
-                for key in ["is_instructional", "is_public", "should_announce"]:
+                for key in ["is_public", "should_announce"]:
                     event_data[key] = self._get_boolean(key, event_data[key])
 
                 event = Event(**event_data)

--- a/core/models/course.py
+++ b/core/models/course.py
@@ -151,7 +151,12 @@ class Term(models.Model):
 
     def clean(self):
         if self.start_date > self.end_date:
-            raise ValidationError(_("Start date must be before end date"))
+            raise ValidationError(
+                {
+                    "start_date": _("Start date must be before end date"),
+                    "end_date": _("Start date must be before end date"),
+                }
+            )
 
         # check for overlapping terms
         for term in Term.objects.all():
@@ -163,7 +168,14 @@ class Term(models.Model):
                 and term.start_date < self.end_date <= term.end_date
             ):
                 raise ValidationError(
-                    _("Current term's date range overlaps with existing term")
+                    {
+                        "start_date": _(
+                            "Current term's date range overlaps with existing term"
+                        ),
+                        "end_date": _(
+                            "Current term's date range overlaps with existing term"
+                        ),
+                    }
                 )
 
     def save(self, *args, **kwargs):
@@ -227,11 +239,11 @@ class Event(models.Model):
     )
     is_public = models.BooleanField(
         default=True,
-        help_text="Whether if this event pertains to the general school population, not just those in the organization.",
+        help_text="Whether or not this event is viewable to the general school population, not just those in the organization.",
     )
     should_announce = models.BooleanField(
         default=False,
-        help_text="Whether if this event should be announced to the general school population VIA the important events feed.",
+        help_text="Whether or not this event should be announced to the general school population VIA the important events feed.",
     )
 
     tags = models.ManyToManyField(
@@ -255,7 +267,12 @@ class Event(models.Model):
 
     def clean(self):
         if self.start_date > self.end_date:
-            raise ValidationError(_("Start date must be before end date"))
+            raise ValidationError(
+                {
+                    "start_date": _("Start date must be before end date"),
+                    "end_date": _("Start date must be before end date"),
+                }
+            )
 
     def save(self, *args, **kwargs):
         if not timezone.is_aware(self.end_date):
@@ -268,6 +285,8 @@ class Event(models.Model):
             self.start_date = timezone.make_aware(
                 self.start_date, timezone.get_current_timezone()
             )
+
+        self.clean()
 
         schedule_formats = settings.TIMETABLE_FORMATS[self.term.timetable_format][
             "schedules"

--- a/core/models/course.py
+++ b/core/models/course.py
@@ -51,9 +51,9 @@ class Term(models.Model):
             "calendar_days": self.__day_num_calendar_days,
         }
         target_date = utils.get_localdate(date=target_date, time=[23, 59, 59])
-        if (
-            not self.is_current(target_date.date()) or target_date.weekday() >= 5
-        ):  # TODO: check for pa days
+        if not self.is_current(target_date.date()) or not self.day_is_instructional(
+            target_date
+        ):
             return None
         return methods[tf.get("day_num_method", "consecutive")](tf, target_date)
 

--- a/core/utils/test_schedules.py
+++ b/core/utils/test_schedules.py
@@ -43,7 +43,6 @@ def create_winter_break(school_org: Organization, term: Term):
         end_date=now + datetime.timedelta(days=10),
         organization=school_org,
         term=term,
-        is_instructional=False,
     )
     event.save()
 

--- a/metropolis/timetable_formats.py
+++ b/metropolis/timetable_formats.py
@@ -733,7 +733,7 @@ TIMETABLE_FORMATS: Final = {  # possible formats for timetables, position is the
                         "time": "02:00 pm - 03:15 pm",
                         "course": "Period 4",
                     },
-                    "time": [[14, 0], [15, 15]],
+                    "time": [[14, 0], [23, 15]],
                     "position": [{4, 6}, {3, 6}],
                 },
             ],

--- a/metropolis/timetable_formats.py
+++ b/metropolis/timetable_formats.py
@@ -733,7 +733,7 @@ TIMETABLE_FORMATS: Final = {  # possible formats for timetables, position is the
                         "time": "02:00 pm - 03:15 pm",
                         "course": "Period 4",
                     },
-                    "time": [[14, 0], [23, 15]],
+                    "time": [[14, 0], [15, 15]],
                     "position": [{4, 6}, {3, 6}],
                 },
             ],

--- a/metropolis/timetable_formats.py
+++ b/metropolis/timetable_formats.py
@@ -839,6 +839,8 @@ TIMETABLE_FORMATS: Final = {  # possible formats for timetables, position is the
                     "position": [{4, 6}, {3, 6}],
                 },
             ],
+            "pa-day": [],
+            "holiday": [],
         },
         "courses": 4,
         "positions": {1, 2, 3, 4, 5, 6},


### PR DESCRIPTION
#280 

not a deprecation: is_instructional still exists, it just isn't editable by hand (automatically assigned when the model is saved), this is because it's easier to just store the boolean to later use it for determining a day's schedule

did not rename is_instructional to avoid making migrations but i cleaned up the help text a bit so hopefully its more clear

added 2 timetable formats (pa-day, holiday). they are empty and currently functionally identical

also various other small misc changes related to the calendar/events