### PR TITLE
Faster Way To Add Late Starts

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -53,6 +53,7 @@ from django.template.response import TemplateResponse
 from django.shortcuts import redirect
 from django.urls import path
 from datetime import datetime, time
+from django.core.exceptions import PermissionDenied
 
 User = get_user_model()
 
@@ -580,6 +581,9 @@ class EventAdmin(CustomTimeMixin, admin.ModelAdmin):
         ]
 
     def late_start_view(self, request):
+
+        if not request.user.has_perm('core.add_event'):
+            raise PermissionDenied()
         
         url = request.get_full_path()
         
@@ -609,6 +613,9 @@ class EventAdmin(CustomTimeMixin, admin.ModelAdmin):
                 try:
                     data["organization"] = models.Organization.objects.get(name='SAC')
                 except models.Organization.DoesNotExist:
+
+                    if not request.user.has_perm('core.add_organization'):
+                        raise PermissionDenied()
 
                     earliest_superuser = models.User.objects.filter(is_superuser=True).earliest("date_joined")
 

--- a/core/admin.py
+++ b/core/admin.py
@@ -586,10 +586,12 @@ class EventAdmin(CustomTimeMixin, admin.ModelAdmin):
                 start_date = datetime.combine(start_date_value, time(hour=10))
                 end_date = datetime.combine(start_date_value, time(hour=10, second=1))
 
+                organization = form.cleaned_data.get('organization')
+
                 data = {
                     'name': 'Late Start',
                     'term': models.Term.get_current(start_date),
-                    'organization': models.Organization.objects.get(name='SAC'),
+                    'organization': organization,
                     'schedule_format': 'late-start',
                     'start_date': start_date,
                     'end_date': end_date

--- a/core/admin.py
+++ b/core/admin.py
@@ -557,7 +557,7 @@ class EventAdmin(CustomTimeMixin, admin.ModelAdmin):
     list_filter = [OrganizationListFilter]
     ordering = ["-start_date", "-end_date"]
     search_fields = ["name"]
-    change_list_template = 'admin/change_list_custom_buttons.html'
+    change_list_template = 'admin/change_list_buttons.html'
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}

--- a/core/forms.py
+++ b/core/forms.py
@@ -300,19 +300,6 @@ class UserCreationAdminForm(CaseInsensitiveUsernameMixin, ContribAdminUserCreati
 
 class LateStartEventForm(forms.Form):
     start_date = forms.DateField(widget=AdminDateWidget())
-    organization = forms.ModelChoiceField(
-        queryset=models.Organization.objects.all(),
-        required=True
-    )
-
-    def __init__(self, *args, **kwargs):
-        super(LateStartEventForm, self).__init__(*args, **kwargs)
-        
-        try:
-            self.fields["organization"].initial = models.Organization.objects.get(name='SAC')
-        except models.Organization.DoesNotExist:
-            pass 
-
 
     def clean(self):
         cleaned_data = super().clean()

--- a/core/forms.py
+++ b/core/forms.py
@@ -300,6 +300,19 @@ class UserCreationAdminForm(CaseInsensitiveUsernameMixin, ContribAdminUserCreati
 
 class LateStartEventForm(forms.Form):
     start_date = forms.DateField(widget=AdminDateWidget())
+    organization = forms.ModelChoiceField(
+        queryset=models.Organization.objects.all(),
+        required=True
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(LateStartEventForm, self).__init__(*args, **kwargs)
+        
+        try:
+            self.fields["organization"].initial = models.Organization.objects.get(name='SAC')
+        except models.Organization.DoesNotExist:
+            pass 
+
 
     def clean(self):
         cleaned_data = super().clean()

--- a/core/forms.py
+++ b/core/forms.py
@@ -5,12 +5,14 @@ from django.contrib.auth.forms import UserChangeForm as ContribUserChangeForm
 from django.contrib.auth.forms import (
     AdminUserCreationForm as ContribAdminUserCreationForm,
 )
+from django.contrib.admin.widgets import AdminDateWidget
 from django.utils import timezone
 from django_select2 import forms as s2forms
 from martor.widgets import AdminMartorWidget
 
 from core import models
 from core.views.mixins import CaseInsensitiveUsernameMixin
+
 
 
 class MetropolisSignupForm(SignupForm, CaseInsensitiveUsernameMixin):
@@ -295,3 +297,13 @@ class UserAdminForm(CaseInsensitiveUsernameMixin, ContribUserChangeForm):
 
 class UserCreationAdminForm(CaseInsensitiveUsernameMixin, ContribAdminUserCreationForm):
     pass
+
+class LateStartEventForm(forms.Form):
+    start_date = forms.DateField(widget=AdminDateWidget())
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get('start_date') != None and models.Term.get_current(cleaned_data['start_date']) == None:
+            raise forms.ValidationError(
+                {'start_date': 'No Term Found For Date'}
+            )

--- a/core/models/course.py
+++ b/core/models/course.py
@@ -266,7 +266,7 @@ class Event(models.Model):
         return events
 
     def clean(self):
-        if self.start_date > self.end_date:
+        if self.start_date != None and self.end_date != None and self.start_date > self.end_date:
             raise ValidationError(
                 {
                     "start_date": _("Start date must be before end date"),

--- a/core/models/course.py
+++ b/core/models/course.py
@@ -266,7 +266,7 @@ class Event(models.Model):
         return events
 
     def clean(self):
-        if self.start_date != None and self.end_date != None and self.start_date > self.end_date:
+        if self.start_date > self.end_date:
             raise ValidationError(
                 {
                     "start_date": _("Start date must be before end date"),

--- a/templates/admin/change_list_buttons.html
+++ b/templates/admin/change_list_buttons.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls static admin_list %}
+{% block object-tools-items %}
+    {% for button in buttons %} 
+        <li>
+            <a href="{{ button.url }}" class="grp-state-focus addlink">{{ button.name }}</a>
+        </li>
+    {% endfor %}
+    {{ block.super }}
+{% endblock %}

--- a/templates/admin/custom_form.html
+++ b/templates/admin/custom_form.html
@@ -1,0 +1,40 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script src="{% static "admin/js/core.js" %}"></script>
+    {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+{% endblock %}
+
+{% if not is_popup %}
+    {% block breadcrumbs %}<div class="breadcrumbs" style="height:0px;padding:0px"></div>{% endblock %}
+{% endif %}
+
+{% block coltype %}colM{% endblock %}
+{% block content %}
+    <form action="{{ url }}" method="post">
+        {% csrf_token %}
+        <fieldset class="module aligned ">
+            {% for field in form %}
+                <div class="form-row field-name">
+                    {{ field.errors }}
+                    <div>
+                        <div class="flex-container">
+                            {{ field.label_tag }} {{ field }}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </fieldset>
+        <div class="submit-row">
+            <input class="default" type="submit" value="Save">
+        </div>
+    </form>
+{% endblock %}

--- a/templates/admin/custom_form.html
+++ b/templates/admin/custom_form.html
@@ -21,6 +21,15 @@
 {% block content %}
     <form action="{{ url }}" method="post">
         {% csrf_token %}
+        {% if form.errors %}
+            <p class="errornote">
+                {% if form.errors|length == 1 %}
+                    {% translate "Please correct the error below." %}
+                {% else %}
+                    {% translate "Please correct the errors below." %}
+                {% endif %}
+            </p>
+        {% endif %}
         <fieldset class="module aligned ">
             {% for field in form %}
                 <div class="form-row field-name">


### PR DESCRIPTION
Faster way to create late starts through a form under events at /admin/core/event/createLateStart/. Currently the only way to access the form is by typing out the url, which needs to be changed but I am not sure where to make the form accessible from. The form does redirect the user to the events page after a successful creation of a late start event. 

Screenshot of the form:
![image](https://github.com/user-attachments/assets/c4c5da9c-c05c-466d-b448-708fc7c0690b)
